### PR TITLE
Update README.md with current link for Google Chart API QR Code Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add the character '~' to a short URL to display a preview page with QR code and 
 Requirements
 -----------
 The following plugins should already be installed and activated:
-1. [YOURLS QRCode](https://github.com/seandrickson/YOURLS-QRCode-Plugin) or [Google Chart API QR Code Plugin](https://github.com/YOURLS/YOURLS/wiki/Plugin-%3D-QRCode-ShortURL)
+1. [YOURLS QRCode](https://github.com/seandrickson/YOURLS-QRCode-Plugin) or [Google Chart API QR Code Plugin](https://yourls.org/docs/development/examples/qrcode)
 2. [Thumbnail URL image](https://github.com/prog-it/yourls-thumbnail-url)
 
 Installation


### PR DESCRIPTION
Old link for the Google Chart API QR Code Plugin was bad as they removed the github wiki and moved everything to the yourls.org website.